### PR TITLE
feat: add structured phased plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -884,6 +884,8 @@ railway deploy
 
 ## 🛣️ **Roadmap**
 
+For a detailed multi-sprint execution strategy, see [PHASED_EXECUTION_PLAN.md](./PHASED_EXECUTION_PLAN.md) or import the structured plan from `src/config/phasedPlan.ts`.
+
 ### **✅ Phase 1: Core Platform** (Complete)
 - ✅ Vector memory storage with OpenAI embeddings
 - ✅ Dual authentication system (JWT + API Keys)

--- a/src/config/phasedPlan.ts
+++ b/src/config/phasedPlan.ts
@@ -1,0 +1,113 @@
+export interface Phase {
+  number: number;
+  title: string;
+  tasks: string[];
+}
+
+export const phasedPlan: Phase[] = [
+  {
+    number: 1,
+    title: 'Documentation Consolidation',
+    tasks: [
+      'Consolidate READMEs into centralized docs/ directory',
+      'Archive outdated docs to archive/ folder',
+      'Update top-level README references to consolidated docs'
+    ]
+  },
+  {
+    number: 2,
+    title: 'Secret Management & Validation',
+    tasks: [
+      'Add startup validation for required environment variables',
+      'Integrate secretlint or equivalent to prevent credential leaks'
+    ]
+  },
+  {
+    number: 3,
+    title: 'CI/CD Security Enhancements',
+    tasks: [
+      'Pin versions for Trivy, Bun setup, and other GitHub Actions',
+      'Add dependency audit step using bun audit or npm audit --audit-level=high',
+      'Enforce minimum coverage thresholds in CI'
+    ]
+  },
+  {
+    number: 4,
+    title: 'Pre-Commit Hooks & Script Linting',
+    tasks: [
+      'Introduce .pre-commit-config.yaml running ESLint, Prettier, Shellcheck',
+      'Lint all deployment and helper scripts with Shellcheck'
+    ]
+  },
+  {
+    number: 5,
+    title: 'Version Management & Releases',
+    tasks: [
+      'Lock CI tool versions for Bun, GitHub Actions, and Docker base images',
+      'Define uniform release workflow across CLI, SDK, and extensions'
+    ]
+  },
+  {
+    number: 6,
+    title: 'Coverage Monitoring',
+    tasks: [
+      'Add Codecov badge to README',
+      'Fail CI if coverage drops below agreed minimum'
+    ]
+  },
+  {
+    number: 7,
+    title: 'AI Orchestrator Enhancement',
+    tasks: [
+      'Scaffold backend orchestrator service with LLM integration and tooling plugins',
+      'Build plugin interface for memory search, external search, code review, and credential management',
+      'Implement retrieval-augmented generation with automatic memory creation and recall'
+    ]
+  },
+  {
+    number: 8,
+    title: 'Dashboard & SDK Integration',
+    tasks: [
+      'Embed orchestrator service into dashboard with persistent chat panel',
+      'Provide enable/disable switch and dynamic API/memory-client configuration loading',
+      'Format plugin outputs into human-friendly cards, links, and rich text'
+    ]
+  },
+  {
+    number: 9,
+    title: 'Credential & MCP Tooling',
+    tasks: [
+      'Build credential manager UI and backend for API keys, secrets, and rotation',
+      'Provide one-click MCP server/client configuration flows for VSCode, Cursor, Windsurf'
+    ]
+  },
+  {
+    number: 10,
+    title: 'External Context Plugins',
+    tasks: [
+      'Integrate web-search API to enrich chat context',
+      'Enable orchestrator to analyze local codebase for live code review'
+    ]
+  },
+  {
+    number: 11,
+    title: 'CI/CD in Fragments',
+    tasks: [
+      'Split CI into workflow fragments per sprint for independent validation and deployment',
+      'Add automated build/test/deploy for orchestrator backend',
+      'Add dashboard integration end-to-end tests for UI embedding and session persistence',
+      'Add verification jobs for each tool/plugin (search, code analysis, credential management)'
+    ]
+  },
+  {
+    number: 12,
+    title: 'End-to-End Demonstration & Docs',
+    tasks: [
+      'Publish walkthrough guide for orchestrator flow end-to-end',
+      'Provide example projects using the SDK, CLI, and dashboard orchestrator',
+      'Tag and release orchestrator and dashboard components as versioned artifacts'
+    ]
+  }
+];
+
+export default phasedPlan;


### PR DESCRIPTION
## Summary
- add TypeScript module exporting multi-phase execution roadmap
- reference phased plan from README

## Testing
- `npm audit --omit=dev` *(fails: audit endpoint returned 403)*
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892a437c2a0832eb0b7c57770365aff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Expanded Roadmap with a link to a phased execution plan, outlining upcoming phases and tasks for better visibility. No functional or API changes.
* Chores
  * Added internal configuration for the phased plan to support planning and transparency. No impact on existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->